### PR TITLE
Add biocviews for rhdf5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,6 @@ Imports:
   SingleCellExperiment,
   Seurat,
   rhdf5
-Remotes:
-  bioc::SingleCellExperiment,rhdf5
-  
+biocViews: 
+SingleCellExperiment, 
+rhdf5 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,5 +18,5 @@ Imports:
   Seurat,
   rhdf5
 biocViews: 
-SingleCellExperiment, 
-rhdf5 
+  SingleCellExperiment, 
+  rhdf5 


### PR DESCRIPTION
Installation was failing as rhdf5 dependency could not be found. Specifying biocviews allows installation of package and dependencies

#5 